### PR TITLE
OpenVPN must run as root user

### DIFF
--- a/root/etc/services.d/openvpn/run
+++ b/root/etc/services.d/openvpn/run
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc openvpn \
+	s6-setuidgid root openvpn \
 	--config /config/openvpn.ovpn \
 	--log /config/log/openvpn.log


### PR DESCRIPTION
The OpenVPN service should run as the root user to be able to create required tun/tap network devices/interfaces. Also the container should be started with the --privileged flag for it to work.


